### PR TITLE
Allow multiple destination subnets for single subnet_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_routes"></a> [additional\_routes](#input\_additional\_routes) | A map where the key is a subnet ID of endpoint subnet for network association and value is a cidr to where traffic should be routed from that subnet. Useful in cases if you need to route beyond the VPC subnet, for instance peered VPC | `map(string)` | `{}` | no |
+| <a name="input_additional_routes"></a> [additional\_routes](#input\_additional\_routes) | A list of maps where each map contains a subnet ID of endpoint subnet for network association and a list of cidrs to where traffic should be routed from that subnet. Useful in cases if you need to route beyond the VPC subnet, for instance peered VPC | `list(map(string))` | `{}` | no |
 | <a name="input_authorization_rules"></a> [authorization\_rules](#input\_authorization\_rules) | Map containing authorization rule configuration. rule\_name = "target\_network\_cidr, access\_group\_id" . | `map(string)` | `{}` | no |
 | <a name="input_authorization_rules_all_groups"></a> [authorization\_rules\_all\_groups](#input\_authorization\_rules\_all\_groups) | Map containing authorization rule configuration with authorize\_all\_groups=true. rule\_name = "target\_network\_cidr" . | `map(string)` | `{}` | no |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | The ARN of ACM certigicate to use for the VPN server config. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -124,9 +124,9 @@ resource "aws_ec2_client_vpn_authorization_rule" "this_all_groups" {
 }
 
 resource "aws_ec2_client_vpn_route" "this_sso" {
-  for_each               = var.additional_routes
+  for_each               = { for r in var.additional_routes : "${r.subnet_id}:${r.destination_cidr_block}" => r }
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.this_sso.id
-  destination_cidr_block = each.value
-  target_vpc_subnet_id   = aws_ec2_client_vpn_network_association.this_sso[each.key].subnet_id
-  description            = "From ${each.key} to ${each.value}"
+  destination_cidr_block = each.value.destination_cidr_block
+  target_vpc_subnet_id   = aws_ec2_client_vpn_network_association.this_sso[each.value.subnet_id].subnet_id
+  description            = "From ${each.value.subnet_id} to ${each.value.destination_cidr_block}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,9 +26,9 @@ variable "endpoint_subnets" {
 }
 
 variable "additional_routes" {
-  description = "A map where the key is a subnet ID of endpoint subnet for network association and value is a cidr to where traffic should be routed from that subnet. Useful in cases if you need to route beyond the VPC subnet, for instance peered VPC"
-  type        = map(string)
-  default     = {}
+  description = "A list of maps where each map contains a subnet ID of endpoint subnet for network association and a cidr to where traffic should be routed from that subnet."
+  type        = list(map(string))
+  default     = []
 }
 
 variable "endpoint_vpc_id" {


### PR DESCRIPTION
I've encountered an issue described in https://github.com/fivexl/terraform-aws-client-vpn-endpoint/issues/10, where single target subnet connects to multiple destination CIDRs (vpc peering). This PR provides a fix for that.


Sample definition of `additional_routes`:

```
  additional_routes = [
    {
      subnet_id           = "subnet-abc123456"
      destination_cidr_block  = "10.2.0.0/16"
    },
    {
      subnet_id           = "subnet-abc123456"
      destination_cidr_block  = "10.4.0.0/16"
    }
  ]
```